### PR TITLE
Fix run command (spring-boot instead of tomcat7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It is created with all the default settings.
 If you want to run the app, it's as simple as using Maven:
 
 ```bash
-mvn tomcat7:run
+mvn spring-boot:run
 ```
 
 Of course, if you are a true Java hipster, you should use the [Yeoman generator](https://github.com/jdubois/generator-jhipster)!


### PR DESCRIPTION
jhipster uses spring-boot instead of tomcat7 since v0.8.0
