### PR TITLE
Cleanup SecurityConfiguration

### DIFF
--- a/src/main/java/com/mycompany/myapp/config/SecurityConfiguration.java
+++ b/src/main/java/com/mycompany/myapp/config/SecurityConfiguration.java
@@ -1,12 +1,9 @@
 package com.mycompany.myapp.config;
 
-import com.mycompany.myapp.config.reload.condition.ConditionalOnSpringLoaded;
 import com.mycompany.myapp.security.*;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.RememberMeAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
@@ -40,34 +37,22 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Inject
     private Http401UnauthorizedEntryPoint authenticationEntryPoint;
 
-    @Bean
-    public RememberMeServices rememberMeServices() {
-        return new CustomPersistentRememberMeServices(env, userDetailsService());
-    }
+    @Inject
+    private UserDetailsService userDetailsService;
 
-    @Bean
-    public RememberMeAuthenticationProvider rememberMeAuthenticationProvider() {
-        return new RememberMeAuthenticationProvider(env.getProperty("jhipster.security.rememberme.key"));
-    }
-
-    @Bean
-    public AuthenticationManager authenticationManager() throws Exception {
-        return super.authenticationManager();
-    }
+    @Inject
+    private RememberMeServices rememberMeServices;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new StandardPasswordEncoder();
     }
 
-    @Bean
-    public UserDetailsService userDetailsService() {
-        return new com.mycompany.myapp.security.UserDetailsService();
-    }
-
-    @Override
-    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-        auth.userDetailsService(userDetailsService()).passwordEncoder(passwordEncoder());
+    @Inject
+    public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
+        auth
+            .userDetailsService(userDetailsService)
+                .passwordEncoder(passwordEncoder());
     }
 
     @Override
@@ -89,7 +74,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .authenticationEntryPoint(authenticationEntryPoint)
                 .and()
             .rememberMe()
-                .rememberMeServices(rememberMeServices())
+                .rememberMeServices(rememberMeServices)
                 .key(env.getProperty("jhipster.security.rememberme.key"))
                 .and()
             .formLogin()


### PR DESCRIPTION
There is some cleanup that can be done in the SecurityConfiguration. I am guessing that much of this probably needs to be cleaned up in the generator rather than just the sample, but at the moment I am pretty swamped so I am submitting this in hopes that someone more familiar can update the generator.
- Clean imports
- Remove unnecessary rememberMeServices() since this is already created via
  classpath scanning
- Remove unnecessary RememberMeAuthenticationProvider. This is already
  created via http.rememberMe().rememberMeServices()
- Remove unnecessary authenticationManager() Bean. This is not necessary
  since the AuthenticationManagerBuilder is being used
- Removed unnecessary UserDetailsService since this is already created via
  classpath scanning
- Use global AuthenticationManagerBuilder to expose to method security
